### PR TITLE
Fixed: rename randomly doesn't work

### DIFF
--- a/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleTree.cs
+++ b/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleTree.cs
@@ -181,7 +181,7 @@ namespace UnityEngine.AssetBundles
             var selectedNodes = context as List<AssetBundleModel.BundleTreeItem>;
             if (selectedNodes != null && selectedNodes.Count > 0)
             {
-                BeginRename(FindItem(selectedNodes[0].bundle.nameHashCode, rootItem), 0.1f);
+                BeginRename(FindItem(selectedNodes[0].bundle.nameHashCode, rootItem));
             }
         }
 


### PR DESCRIPTION
For some reason, some times selecting "rename" on the asset bundle name doesn't work.

Removing the small delay seems to fix this issue.