### PR TITLE
AssetBundleBuildTab.cs Fix InvalidOperationException.

### DIFF
--- a/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleBuildTab.cs
+++ b/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleBuildTab.cs
@@ -254,7 +254,7 @@ namespace UnityEngine.AssetBundles
             EditorGUILayout.Space();
             if (GUILayout.Button("Build") )
             {
-                ExecuteBuild();
+                EditorApplication.delayCall += ExecuteBuild;
             }
             GUILayout.EndVertical();
             EditorGUILayout.EndScrollView();


### PR DESCRIPTION
After building, the following message appeared.
InvalidOperationException: Operation is not valid due to the current state of the object
System.Collections.Stack.Pop () (at /Users/builduser/buildslave/mono/build/mcs/class/corlib/System.Collections/Stack.cs:329)
UnityEngine.GUILayoutUtility.EndLayoutGroup () (at C:/buildslave/unity/build/Runtime/IMGUI/Managed/GUILayoutUtility.cs:323)
UnityEngine.GUILayout.EndScrollView (Boolean handleScrollWheel) (at C:/buildslave/unity/build/Runtime/IMGUI/Managed/GUILayout.cs:435)
UnityEditor.EditorGUILayout.EndScrollView () (at C:/buildslave/unity/build/Editor/Mono/EditorGUI.cs:7527)
UnityEngine.AssetBundles.AssetBundleBuildTab.OnGUI (Rect pos) (at Assets/AssetBundles-Browser/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleBuildTab.cs:260)
UnityEngine.AssetBundles.AssetBundleBrowserMain.OnGUI () (at Assets/AssetBundles-Browser/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleBrowserMain.cs:113)
System.Reflection.MonoMethod.Invoke (System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at /Users/builduser/buildslave/mono/build/mcs/class/corlib/System.Reflection/MonoMethod.cs:222)

Running ExecuteBuild after correctly terminating OnGUI processing eliminated the problem.