### PR TITLE
Suppress OnGUI() issue on long build

### DIFF
--- a/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleBuildTab.cs
+++ b/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleBuildTab.cs
@@ -254,7 +254,7 @@ namespace UnityEngine.AssetBundles
             EditorGUILayout.Space();
             if (GUILayout.Button("Build") )
             {
-                ExecuteBuild();
+                EditorApplication.delayCall += ExecuteBuild;
             }
             GUILayout.EndVertical();
             EditorGUILayout.EndScrollView();


### PR DESCRIPTION
Running Build inside OnGUI() code can raise exceptions from OnGUI, such as InvalidOperationException. Using delayCall can weave this issue. 