### PR TITLE
Correct null ref exception when viewing bundle variants.

### DIFF
--- a/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/InspectTab/InspectTreeView.cs
+++ b/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/InspectTab/InspectTreeView.cs
@@ -8,51 +8,11 @@ namespace UnityEngine.AssetBundles
 {
 	public class InspectTreeItem : TreeViewItem
 	{
-		private string m_BundlePath;
-        public string bundlePath
-        {
-            get { return m_BundlePath; }
-        }
-		private AssetBundle m_Bundle;
-
-		private AssetBundleInspectTab m_InspectTab;
-		//public InspectTreeItem(int id, int depth, string displayName) : base(id, depth, displayName)
-		public InspectTreeItem(string path, AssetBundleInspectTab inspectTab) : base(path.GetHashCode(), 0, path)
+        public string bundlePath { get; private set; }
+            
+		public InspectTreeItem(string path) : base(path.GetHashCode(), 0, path)
 		{
-			m_BundlePath = path;
-			m_Bundle = null;
-			m_InspectTab = inspectTab;
-		}
-		public AssetBundle bundle
-		{
-			get
-			{
-                if (m_Bundle == null)
-                    LoadBundle();
-				return m_Bundle;
-			}
-		}
-		public void LoadBundle()
-		{
-			if (m_Bundle == null)
-			{
-				m_Bundle = AssetBundle.LoadFromFile(m_BundlePath);
-                m_InspectTab.SaveBundle(m_Bundle);
-
-                //AssetBundleManifest manifest = m_Bundle.LoadAsset<AssetBundleManifest>("AssetBundleManifest");
-                //if (manifest != null)
-                //{
-                //    //this is where we could get some overall data. if we wanted it. which we might. someday.
-                //}
-
-
-                //gotta actually load assets to keep inspector from crashing :(
-                var content = m_Bundle.GetAllAssetNames();
-                foreach (var c in content)
-                {
-                    m_Bundle.LoadAsset(c);
-                }
-            }
+            this.bundlePath = path;
 		}
 	}
 
@@ -75,7 +35,7 @@ namespace UnityEngine.AssetBundles
 			{
 				foreach (var b in m_InspectTab.BundleList)
 				{
-					root.AddChild(new InspectTreeItem(b, m_InspectTab));
+					root.AddChild(new InspectTreeItem(b));
 				}
 			}
 			return root;
@@ -99,7 +59,9 @@ namespace UnityEngine.AssetBundles
 				m_InspectTab.SetBundleItem(FindItem(selectedIds[0], rootItem) as InspectTreeItem);
 			}
 			else
+            {
 				m_InspectTab.SetBundleItem(null);
+            }
 		}
 
 		protected override bool CanMultiSelect(TreeViewItem item)

--- a/UnityEngine.AssetBundles/Editor/Tests/ABModelTests.cs
+++ b/UnityEngine.AssetBundles/Editor/Tests/ABModelTests.cs
@@ -45,25 +45,43 @@ public class ABModelTests
     [Test]
     public void AddBundlesToUpdate_AddsCorrectBundles_ToUpdateQueue()
     {
+        // Account for existing asset bundles
+        int numBundles = ABModelUtil.BundlesToUpdate.Count;
+
         Model.AddBundlesToUpdate(m_BundleInfo);
-        Assert.AreEqual(3, ABModelUtil.BundlesToUpdate.Count);
+        Assert.AreEqual(numBundles + 3, ABModelUtil.BundlesToUpdate.Count);
     }
 
     [Test]
     public void Update_ReturnsTrue_ForRepaintOnFinalElement()
     {
+        // Account for existing bundles
+        int numChildren = ABModelUtil.Root.GetChildList().Count;
+
         Model.AddBundlesToUpdate(m_BundleInfo);
-        Assert.IsFalse(Model.Update());
-        Assert.IsFalse(Model.Update());
-        Assert.IsTrue(Model.Update());
+
+        for (int i = 0; i < numChildren; ++i)
+        {
+            if (i < numChildren)
+            {
+                Assert.IsFalse(Model.Update());
+            }
+            else
+            {
+                Assert.IsTrue(Model.Update());
+            }
+        }
     }
 
     [Test]
     public void ModelRebuild_Clears_BundlesToUpdate()
     {
+        // Account for existing bundles
+        int numChildren = ABModelUtil.Root.GetChildList().Count;
+
         Model.AddBundlesToUpdate(m_BundleInfo);
         Model.Rebuild();
-        Assert.AreEqual(0, ABModelUtil.BundlesToUpdate.Count);
+        Assert.AreEqual(numChildren, ABModelUtil.BundlesToUpdate.Count);
     }
 
     [Test]
@@ -74,15 +92,20 @@ public class ABModelTests
     }
 
     [Test]
-    public void ValidateAssetBundleListIsZeroWhenNoBundleExist()
+    public void ValidateAssetBundleListMatchesAssetDatabase()
     {
+        int numBundles = AssetDatabase.GetAllAssetBundleNames().Length;
+
         string[] list = Model.ValidateBundleList();
-        Assert.AreEqual(0, list.Length);
+        Assert.AreEqual(numBundles, list.Length);
     }
 
     [Test]
     public void ValidateAssetBundleList_ReturnsCorrect_ListOfBundles()
     {
+        // Account for existing bundles
+        int numBundles = AssetDatabase.GetAllAssetBundleNames().Length;
+
         List<string> listOfPrefabs = new List<string>();
         string bundleName = "bundletest";
 
@@ -95,7 +118,7 @@ public class ABModelTests
             string[] list = Model.ValidateBundleList();
 
             //Assert
-            Assert.AreEqual(1, list.Length);
+            Assert.AreEqual(numBundles + 1, list.Length);
             Assert.AreEqual(bundleName, list[0]);
         }, listOfPrefabs);
     }
@@ -103,6 +126,9 @@ public class ABModelTests
     [Test]
     public void ValidateAssetBundleList_WithVariants_ContainsCorrectList()
     {
+        // Account for existing bundles
+        int numBundles = AssetDatabase.GetAllAssetBundleNames().Length;
+
         List<string> listOfPrefabs = new List<string>();
 
         string bundleName = "bundletest";
@@ -116,7 +142,7 @@ public class ABModelTests
             string[] list = Model.ValidateBundleList();
 
             //Assert
-            Assert.AreEqual(2, list.Length);
+            Assert.AreEqual(numBundles + 2, list.Length);
             Assert.AreEqual(bundleName + ".v1", list[0]);
             Assert.AreEqual(bundleName + ".v2", list[1]);
         }, listOfPrefabs);
@@ -125,6 +151,9 @@ public class ABModelTests
     [Test]
     public void ModelRebuild_KeepsCorrect_BundlesToUpdate()
     {
+        // Account for existing bundles
+        int numChildren = ABModelUtil.Root.GetChildList().Count;
+
         List<string> listOfPrefabs = new List<string>();
 
         string bundleName = "bundletest";
@@ -139,7 +168,7 @@ public class ABModelTests
             var rootChildList = ABModelUtil.Root.GetChildList();
 
             //Checks that the root has 1 bundle variant folder object as a child
-            Assert.AreEqual(1, rootChildList.Count);
+            Assert.AreEqual(numChildren + 1, rootChildList.Count);
             Assert.AreEqual(typeof(BundleVariantFolderInfo), rootChildList.FirstOrDefault().GetType());
 
             BundleVariantFolderInfo folderInfo = rootChildList.FirstOrDefault() as BundleVariantFolderInfo;
@@ -153,6 +182,9 @@ public class ABModelTests
     [Test]
     public void VerifyBasicTreeStructure_ContainsCorrect_ClassTypes()
     {
+        // Account for existing bundles
+        int numChildren = ABModelUtil.Root.GetChildList().Count;
+
         List<string> listOfPrefabs = new List<string>();
         string bundleName = "bundletest";
 
@@ -164,7 +196,7 @@ public class ABModelTests
             Model.Refresh();
 
             var rootChildList = ABModelUtil.Root.GetChildList();
-            Assert.AreEqual(1, rootChildList.Count);
+            Assert.AreEqual(numChildren + 1, rootChildList.Count);
             Assert.AreEqual(typeof(BundleVariantFolderInfo), rootChildList.FirstOrDefault().GetType());
 
             BundleVariantFolderInfo folderInfo = rootChildList.FirstOrDefault() as BundleVariantFolderInfo;
@@ -180,18 +212,20 @@ public class ABModelTests
     [Test]
     public void CreateEmptyBundle_AddsBundle_ToRootBundles()
     {
-        Assert.AreEqual(0, GetBundleRootFolderChildCount());
+        // Account for existing bundles
+        int numChildren = GetBundleRootFolderChildCount();
 
         string bundleName = "testname";
         Model.CreateEmptyBundle(null, bundleName);
 
-        Assert.AreEqual(1, GetBundleRootFolderChildCount());
+        Assert.AreEqual(numChildren + 1, GetBundleRootFolderChildCount());
     }
 
     [Test]
     public void CreatedEmptyBundle_Remains_AfterRefresh()
     {
-        Assert.AreEqual(0, GetBundleRootFolderChildCount());
+        // Account for existing bundles
+        int numChildren = GetBundleRootFolderChildCount();
 
         //Arrange
         string bundleName = "testname";
@@ -201,20 +235,21 @@ public class ABModelTests
         Model.Refresh();
 
         //Assert
-        Assert.AreEqual(1, GetBundleRootFolderChildCount());
+        Assert.AreEqual(numChildren + 1, GetBundleRootFolderChildCount());
     }
 
     [Test]
     public void CreatedEmptyBundle_IsRemoved_AfterRebuild()
     {
-        Assert.AreEqual(0, GetBundleRootFolderChildCount());
+        // Account for existing bundles
+        int childCount = GetBundleRootFolderChildCount();
 
         string bundleName = "testname";
         Model.CreateEmptyBundle(null, bundleName);
 
         Model.Rebuild();
 
-        Assert.AreEqual(0, GetBundleRootFolderChildCount());
+        Assert.AreEqual(childCount, GetBundleRootFolderChildCount());
     }
 
     [Test]
@@ -334,6 +369,9 @@ public class ABModelTests
     [Test]
     public void BundleFolderInfo_ChildrenTable_UpdatesWhenBundleIsRenamed()
     {
+        // Account for existing asset bundles
+        int numExistingChildren = ABModelUtil.Root.GetChildList().Count;
+
         List<string> listOfPrefabs = new List<string>();
 
         string bundle1Name = "bundle1";
@@ -348,9 +386,9 @@ public class ABModelTests
             BundleTreeItem treeItem = new BundleTreeItem(b, 0, ABModelUtil.FakeTexture2D);
             Model.ExecuteAssetMove();
 
-            Assert.AreEqual(bundle1Name, ABModelUtil.Root.GetChildList().ElementAt(0).m_Name.bundleName);
+            Assert.AreEqual(bundle1Name, ABModelUtil.Root.GetChildList().ElementAt(numExistingChildren).m_Name.bundleName);
             Model.HandleBundleRename(treeItem, bundle2Name);
-            Assert.AreEqual(bundle2Name, ABModelUtil.Root.GetChildList().ElementAt(0).m_Name.bundleName);
+            Assert.AreEqual(bundle2Name, ABModelUtil.Root.GetChildList().ElementAt(numExistingChildren).m_Name.bundleName);
 
         }, listOfPrefabs);
     }
@@ -466,6 +504,9 @@ public class ABModelTests
     [Test]
     public void HandleBundleDelete_Deletes_BundleDataInfo()
     {
+        // Account for existing asset bundles
+        int numChilren = ABModelUtil.Root.GetChildList().Count;
+
         BundleDataInfo bundleDataInfo1 = new BundleDataInfo("bundle1", ABModelUtil.Root);
         BundleDataInfo bundleDataInfo2 = new BundleDataInfo("bundle2", ABModelUtil.Root);
         BundleDataInfo bundleDataInfo3 = new BundleDataInfo("bundle3", ABModelUtil.Root);
@@ -480,12 +521,15 @@ public class ABModelTests
         Dictionary<string, BundleInfo> numberOfConcreteFolderChildren =
             numberOfChildrenFieldInfo.GetValue(ABModelUtil.Root) as Dictionary<string, BundleInfo>;
 
-        Assert.AreEqual(0, numberOfConcreteFolderChildren.Keys.Count);
+        Assert.AreEqual(numChilren, numberOfConcreteFolderChildren.Keys.Count);
     }
 
     [Test]
     public void HandleBundleDelete_Deletes_VariantFolderAndChildren()
     {
+        // Account for existing asset bundles
+        int numChildren = ABModelUtil.Root.GetChildList().Count;
+
         BundleVariantFolderInfo bundleVariantFolderRoot = new BundleVariantFolderInfo("variantFolder", ABModelUtil.Root);
         ABModelUtil.Root.AddChild(bundleVariantFolderRoot);
 
@@ -503,19 +547,23 @@ public class ABModelTests
         Dictionary<string, BundleInfo> numberOfConcreteFolderChildren =
             numberOfChildrenFieldInfo.GetValue(ABModelUtil.Root) as Dictionary<string, BundleInfo>;
 
-        Assert.AreEqual(1, numberOfConcreteFolderChildren.Keys.Count);
+        Assert.AreEqual(numChildren + 1, numberOfConcreteFolderChildren.Keys.Count);
 
         Model.HandleBundleDelete(new BundleInfo[] { bundleVariantFolderRoot });
 
         numberOfConcreteFolderChildren =
             numberOfChildrenFieldInfo.GetValue(ABModelUtil.Root) as Dictionary<string, BundleInfo>;
 
-        Assert.AreEqual(0, numberOfConcreteFolderChildren.Keys.Count);
+        Assert.AreEqual(numChildren, numberOfConcreteFolderChildren.Keys.Count);
     }
 
     [Test]
     public void HandleBundleDelete_Deletes_SingleVariantFromVariantFolder()
     {
+        // Account for existing asset bundles
+        int numChildren = ABModelUtil.Root.GetChildList().Count;
+        int numBundles = AssetDatabase.GetAllAssetBundleNames().Length;
+
         BundleVariantFolderInfo bundleVariantFolderRoot = new BundleVariantFolderInfo("variantFolder", ABModelUtil.Root);
         ABModelUtil.Root.AddChild(bundleVariantFolderRoot);
 
@@ -536,14 +584,14 @@ public class ABModelTests
         Dictionary<string, BundleInfo> numberOfConcreteFolderChildren =
             numberOfChildrenFieldInfo.GetValue(ABModelUtil.Root) as Dictionary<string, BundleInfo>;
 
-        Assert.AreEqual(1, numberOfConcreteFolderChildren.Keys.Count);
+        Assert.AreEqual(numChildren + 1, numberOfConcreteFolderChildren.Keys.Count);
 
         Model.HandleBundleDelete(new BundleInfo[] { bundleVariantDataInfo1 });
 
         numberOfConcreteFolderChildren =
             numberOfChildrenFieldInfo.GetValue(ABModelUtil.Root) as Dictionary<string, BundleInfo>;
 
-        Assert.AreEqual(1, numberOfConcreteFolderChildren.Keys.Count);
+        Assert.AreEqual(numChildren + 1, numberOfConcreteFolderChildren.Keys.Count);
 
         FieldInfo numberOfVariantFolderChildrenFieldInfo = typeof(BundleVariantFolderInfo).GetField("m_Children", BindingFlags.NonPublic | BindingFlags.Instance);
         Dictionary<string, BundleInfo> numberOfVariantFolderChildren =
@@ -555,6 +603,9 @@ public class ABModelTests
     [Test]
     public void HandleBundleMerge_Merges_BundlesCorrectly()
     {
+        // Account for existing bundles
+        int numBundles = AssetDatabase.GetAllAssetBundleNames().Length;
+
         string bundle1Name = "bundle1";
         string bundle2Name = "bundle2";
 
@@ -573,7 +624,7 @@ public class ABModelTests
         {
             Model.HandleBundleMerge(new BundleInfo[] {bundle2DataInfo}, bundle1DataInfo);
 
-            Assert.AreEqual(1, AssetDatabase.GetAllAssetBundleNames().Length);
+            Assert.AreEqual(numBundles + 1, AssetDatabase.GetAllAssetBundleNames().Length);
             Assert.AreEqual(bundle1Name, AssetDatabase.GetAllAssetBundleNames()[0]);
 
             //Make sure every asset now has bundle1 as the bundle name
@@ -588,6 +639,9 @@ public class ABModelTests
     [Test]
     public void HandleBundleMerge_Merges_BundlesWithChildrenCorrectly()
     {
+        // Account for existing bundles
+        int numBundles = AssetDatabase.GetAllAssetBundleNames().Length;
+
         string folderName = "folder";
         string bundle1Name = "bundle1";
         string bundle2Name = folderName + "/bundle2";
@@ -606,7 +660,7 @@ public class ABModelTests
         {
             Model.HandleBundleMerge(new BundleInfo[] { bundle1DataInfo }, bundle2DataInfo);
 
-            Assert.AreEqual(1, AssetDatabase.GetAllAssetBundleNames().Length, GetAllElementsAsString(AssetDatabase.GetAllAssetBundleNames()));
+            Assert.AreEqual(numBundles + 1, AssetDatabase.GetAllAssetBundleNames().Length, GetAllElementsAsString(AssetDatabase.GetAllAssetBundleNames()));
             Assert.AreEqual(bundle2Name, AssetDatabase.GetAllAssetBundleNames()[0]);
 
             //Make sure every asset now has bundle1 as the bundle name


### PR DESCRIPTION
Fixed problems experienced while viewing asset bundle variants in the Asset Bundle Browser.
* InspectTreeItem now only contains a path to the bundle to inspect.
* AssetBundleInspectTab is now responsible for loading/unloading asset bundles.
* Corrected unit tests to account for existing asset bundles the project may contain.
* Allows consumers of this code to copy the tests along with the browser over to their project.

Reproduction steps:

1. Pull the Asset Bundle Browser into a new unity project.
2. Run unit tests under "Window / Test Runner", they should all pass
3. Pull up the Asset Bundle Browser, it should be empty.
4. Create a prefab in your project, name it something like "myTestObject", assign it to a bundle named something like "myTestObject", no variant.
5. Create two more prefabs in your project, assign them to a bundle named "myTestVariant" with variants "one" and "two" respectively
6. Pull up the Asset Bundle Browser under the "Window" menu and make sure the bundles are in the "Configure" tab
7. Switch to the "Build" tab and build the bundles
8. Switch to the "Inspect" tab and select each of the entries in turn, you should not experience any null ref exceptions
9. Run the unit tests, they should all pass.
10. Delete the asset bundles from the project via the Asset Bundle Browser
11. Delete the built asset bundles from the project
12. Run the unit tests again, they should all pass.