### PR TITLE
Add asset dependency information message

### DIFF
--- a/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleModel/ABModelAssetInfo.cs
+++ b/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleModel/ABModelAssetInfo.cs
@@ -173,7 +173,25 @@ namespace UnityEngine.AssetBundles.AssetBundleModel
                 }
                 message = message.Substring(0, message.Length - 2);//remove trailing comma.
                 messages.Add(new MessageSystem.Message(message, MessageType.Info));
-            }
+            }            
+
+            if (m_dependencies != null && m_dependencies.Count > 0)
+            {
+                var message = string.Empty;
+                foreach (var dependent in m_dependencies)
+                {
+                    if (dependent.bundleName != bundleName)
+                    {
+                        message += dependent.bundleName + " : " + dependent.displayName + "\n";
+                    }
+                }
+                if (string.IsNullOrEmpty(message) == false)
+                {
+                    message.Insert(0, displayName + "\n" + "Is dependent on other bundle's asset(s) or auto included asset(s): \n");
+                    message = message.Substring(0, message.Length - 1);//remove trailing line break.
+                    messages.Add(new MessageSystem.Message(message, MessageType.Info));
+                }
+            }            
 
             messages.Add(new MessageSystem.Message(displayName + "\n" + "Path: " + fullAssetName, MessageType.Info));
 

--- a/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleModel/ABModelAssetInfo.cs
+++ b/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleModel/ABModelAssetInfo.cs
@@ -187,7 +187,7 @@ namespace UnityEngine.AssetBundles.AssetBundleModel
                 }
                 if (string.IsNullOrEmpty(message) == false)
                 {
-                    message.Insert(0, displayName + "\n" + "Is dependent on other bundle's asset(s) or auto included asset(s): \n");
+                    message = message.Insert(0, displayName + "\n" + "Is dependent on other bundle's asset(s) or auto included asset(s): \n");
                     message = message.Substring(0, message.Length - 1);//remove trailing line break.
                     messages.Add(new MessageSystem.Message(message, MessageType.Info));
                 }


### PR DESCRIPTION
Additional information for dependency resolving

I'm working on removing unnecessary dependencies between assetbundles.
Knowing which asset is dependent on other bundle is very helpful
Also added auto included assets too, because i think dependent on auto included assets is just a timebomb