### PR TITLE
Changed logic for DirectoryCopy method to allow override of files

### DIFF
--- a/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleBuildTab.cs
+++ b/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleBuildTab.cs
@@ -373,21 +373,8 @@ namespace UnityEngine.AssetBundles
                 Directory.CreateDirectory(destDirName);
             }
 
-            // Get the files in the directory and copy them to the new location.
-            FileInfo[] files = dir.GetFiles();
-            foreach (FileInfo file in files)
-            {
-                string temppath = Path.Combine(destDirName, file.Name);
-                file.CopyTo(temppath, false);
-            }
-
-
-            DirectoryInfo[] dirs = dir.GetDirectories();
-            foreach (DirectoryInfo subdir in dirs)
-            {
-                string temppath = Path.Combine(destDirName, subdir.Name);
-                DirectoryCopy(subdir.FullName, temppath);
-            }
+            foreach (string dirPath in Directory.GetFiles(sourceDirName, "*.*", SearchOption.AllDirectories))
+                File.Copy(dirPath, dirPath.Replace(sourceDirName, destDirName), true);
         }
 
         private void BrowseForFolder()

--- a/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleBuildTab.cs
+++ b/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleBuildTab.cs
@@ -364,17 +364,22 @@ namespace UnityEngine.AssetBundles
 
         private static void DirectoryCopy(string sourceDirName, string destDirName)
         {
-            // Get the subdirectories for the specified directory.
-            DirectoryInfo dir = new DirectoryInfo(sourceDirName);
-
             // If the destination directory doesn't exist, create it.
             if (!Directory.Exists(destDirName))
             {
                 Directory.CreateDirectory(destDirName);
             }
 
+            foreach (string folderPath in Directory.GetDirectories(sourceDirName, "*", SearchOption.AllDirectories))
+            {
+                if (!Directory.Exists(folderPath.Replace(sourceDirName, destDirName)))
+                    Directory.CreateDirectory(folderPath.Replace(sourceDirName, destDirName));
+            }
+
             foreach (string dirPath in Directory.GetFiles(sourceDirName, "*.*", SearchOption.AllDirectories))
+            {
                 File.Copy(dirPath, dirPath.Replace(sourceDirName, destDirName), true);
+            }
         }
 
         private void BrowseForFolder()

--- a/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleBuildTab.cs
+++ b/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleBuildTab.cs
@@ -376,9 +376,12 @@ namespace UnityEngine.AssetBundles
                     Directory.CreateDirectory(folderPath.Replace(sourceDirName, destDirName));
             }
 
-            foreach (string dirPath in Directory.GetFiles(sourceDirName, "*.*", SearchOption.AllDirectories))
+            foreach (string filePath in Directory.GetFiles(sourceDirName, "*.*", SearchOption.AllDirectories))
             {
-                File.Copy(dirPath, dirPath.Replace(sourceDirName, destDirName), true);
+                string newFilePath = Path.Combine(Path.GetDirectoryName(filePath).Replace(sourceDirName, destDirName),
+                    Path.GetFileName(filePath));
+
+                File.Copy(filePath, newFilePath, true);
             }
         }
 


### PR DESCRIPTION
A fogbugz case described an issue where the Copy To Streaming Assets wasn't allowing file overwrite.

The new logic overwrites files that have changed.