### PR TITLE
Inspect tab now uses an add/remove button

### DIFF
--- a/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleBuildTab.cs
+++ b/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleBuildTab.cs
@@ -51,6 +51,8 @@ namespace UnityEngine.AssetBundles
             public BuildAssetBundleOptions option;
         }
 
+        private AssetBundleInspectTab m_InspectTab;
+
         [SerializeField]
         private BuildTabData m_UserData;
 
@@ -97,6 +99,7 @@ namespace UnityEngine.AssetBundles
         }
         public void OnEnable(Rect pos, EditorWindow parent)
         {
+            m_InspectTab = (parent as AssetBundleBrowserMain).m_InspectTab;
 
             //LoadData...
             var dataPath = System.IO.Path.GetFullPath(".");
@@ -353,6 +356,7 @@ namespace UnityEngine.AssetBundles
             buildInfo.outputDirectory = m_UserData.m_OutputPath;
             buildInfo.options = opt;
             buildInfo.buildTarget = (BuildTarget)m_UserData.m_BuildTarget;
+            buildInfo.onBuild = (assetBundleName) => m_InspectTab.AddFilePath(string.Format("{0}/{1}", buildInfo.outputDirectory, assetBundleName));
 
             AssetBundleModel.Model.DataSource.BuildAssetBundles (buildInfo);
 

--- a/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleDataSource/ABDataSource.cs
+++ b/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleDataSource/ABDataSource.cs
@@ -1,4 +1,5 @@
-﻿using UnityEditor;
+﻿using System;
+using UnityEditor;
 
 namespace UnityEngine.AssetBundles.AssetBundleDataSource
 {
@@ -7,6 +8,7 @@ namespace UnityEngine.AssetBundles.AssetBundleDataSource
         public string outputDirectory;
         public BuildAssetBundleOptions options;
         public BuildTarget buildTarget;
+        public Action<string> onBuild;
     }
 
     public partial interface ABDataSource

--- a/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleDataSource/AssetDatabaseABDataSource.cs
+++ b/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleDataSource/AssetDatabaseABDataSource.cs
@@ -78,8 +78,11 @@ namespace UnityEngine.AssetBundles.AssetBundleDataSource
         }
 
         public bool BuildAssetBundles (ABBuildInfo info) {
-            BuildPipeline.BuildAssetBundles(info.outputDirectory, info.options, info.buildTarget);
-
+            var buildManifest = BuildPipeline.BuildAssetBundles(info.outputDirectory, info.options, info.buildTarget);
+            foreach(var assetBundleName in buildManifest.GetAllAssetBundles())
+            {
+                info.onBuild(assetBundleName);
+            }
             return true;
         }
     }

--- a/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleDataSource/AssetDatabaseABDataSource.cs
+++ b/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/AssetBundleDataSource/AssetDatabaseABDataSource.cs
@@ -81,7 +81,10 @@ namespace UnityEngine.AssetBundles.AssetBundleDataSource
             var buildManifest = BuildPipeline.BuildAssetBundles(info.outputDirectory, info.options, info.buildTarget);
             foreach(var assetBundleName in buildManifest.GetAllAssetBundles())
             {
-                info.onBuild(assetBundleName);
+                if (info.onBuild != null)
+                {
+                    info.onBuild(assetBundleName);
+                }
             }
             return true;
         }

--- a/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/InspectTab/AssetBundleInspectTab.cs
+++ b/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/InspectTab/AssetBundleInspectTab.cs
@@ -156,7 +156,6 @@ namespace UnityEngine.AssetBundles
         {
             m_Data.RemovePath(m_SelectedBundleTreeItem.bundlePath);
             RefreshBundles();
-            m_BundleTreeView.Reload();
             m_SelectedBundleTreeItem = null;
         }
 

--- a/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/InspectTab/AssetBundleInspectTab.cs
+++ b/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/InspectTab/AssetBundleInspectTab.cs
@@ -194,42 +194,53 @@ namespace UnityEngine.AssetBundles
                 if (newPath.StartsWith(gamePath))
                     newPath = newPath.Remove(0, gamePath.Length + 1);
 
-                var bundleTestPath = this.LoadBundle(newPath);
-                if (bundleTestPath != null)
-                {
-                    this.UnloadBundle(bundleTestPath.name);
-                    m_Data.AddPath(newPath);
-                }
-                else
-                {
-                    Debug.Log("Specified path is not an asset bundle!");
-                }
+                AddFilePath(newPath);
 
                 RefreshBundles();
             }
         }
 
         //TODO - this is largely copied from BuildTab, should maybe be shared code.
-        private void BrowseForFolder()
+        private void BrowseForFolder(string folderPath = null)
         {
-            var newPath = EditorUtility.OpenFolderPanel("Bundle Folder", string.Empty, string.Empty);
-            if (!string.IsNullOrEmpty(newPath))
+           folderPath = EditorUtility.OpenFolderPanel("Bundle Folder", string.Empty, string.Empty);
+            if (!string.IsNullOrEmpty(folderPath))
             {
                 var gamePath = System.IO.Path.GetFullPath(".");//TODO - FileUtil.GetProjectRelativePath??
                 gamePath = gamePath.Replace("\\", "/");
-                if (newPath.StartsWith(gamePath))
-                    newPath = newPath.Remove(0, gamePath.Length + 1);
+                if (folderPath.StartsWith(gamePath))
+                    folderPath = folderPath.Remove(0, gamePath.Length + 1);
 
-                AddFolderFilePath(newPath);
+                AddFolderFilePath(folderPath);
 
                 RefreshBundles();
             }
         }
 
-        private void AddFolderFilePath(string folderPath)
+        public void AddFilePath(string filePath)
+        {
+            if (m_Data.Contains(filePath))
+                return;
+
+            var bundleTestPath = this.LoadBundle(filePath);
+            if (bundleTestPath != null)
+            {
+                this.UnloadBundle(bundleTestPath.name);
+                m_Data.AddPath(filePath);
+            }
+            else
+            {
+                Debug.Log("Specified path is not an asset bundle!");
+            }
+        }
+
+        public void AddFolderFilePath(string folderPath)
         {
             foreach (var filePath in Directory.GetFiles(folderPath))
             {
+                if (m_Data.Contains(filePath))
+                    continue;
+
                 var bundleTestPath = this.LoadBundle(filePath);
                 if (bundleTestPath != null)
                 {
@@ -329,6 +340,11 @@ namespace UnityEngine.AssetBundles
                 {
                     m_BundlePaths.Remove(pathToRemove);
                 }
+            }
+
+            public bool Contains(string pathToCheck)
+            {
+                return m_BundlePaths.Contains(pathToCheck);
             }
         }
 

--- a/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/InspectTab/InspectTreeView.cs
+++ b/UnityEngine.AssetBundles/Editor/AssetBundleBrowser/InspectTab/InspectTreeView.cs
@@ -2,7 +2,7 @@ using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using System.Collections.Generic;
 using System.IO;
-using System;
+using System.Linq;
 
 namespace UnityEngine.AssetBundles
 {
@@ -56,7 +56,8 @@ namespace UnityEngine.AssetBundles
 			
 			if (selectedIds.Count > 0)
 			{
-				m_InspectTab.SetBundleItem(FindItem(selectedIds[0], rootItem) as InspectTreeItem);
+                m_InspectTab.SetBundleItem(FindRows(selectedIds).Select(tvi => tvi as InspectTreeItem).ToList());
+				//m_InspectTab.SetBundleItem(FindItem(selectedIds[0], rootItem) as InspectTreeItem);
 			}
 			else
             {
@@ -66,7 +67,7 @@ namespace UnityEngine.AssetBundles
 
 		protected override bool CanMultiSelect(TreeViewItem item)
 		{
-			return false;
+			return true;
 		}
 	}
 


### PR DESCRIPTION
- choose which files to load in as asset bundles directly with add button
- remove button becomes active when user has an asset bundle selected, and when clicked, it removes it

My asset bundles don't use the same name as their .manifest file as needed before, and it's very possible others do the same. Also, I don't keep all my asset bundles in the same directory. Figured an add/remove system for this may solve these issues :)

This tool is great though - learned about it from Unite 👍 