### PR TITLE
System.Reflection.TypeLoadException

### DIFF
--- a/Editor/AssetBundleDataSource/ABDataSourceProvider.cs
+++ b/Editor/AssetBundleDataSource/ABDataSourceProvider.cs
@@ -25,19 +25,26 @@ namespace AssetBundleBrowser.AssetBundleDataSource
             var x = AppDomain.CurrentDomain.GetAssemblies();
             foreach (var assembly in x)
             {
-                var list = new List<Type>(
-                    assembly
-                    .GetTypes()
-                    .Where(t => t != typeof(ABDataSource))
-                    .Where(t => typeof(ABDataSource).IsAssignableFrom(t)));
-
-
-                for (int count = 0; count < list.Count; count++)
+                try
                 {
-                    if (list[count].Name == "AssetDatabaseABDataSource")
-                        properList[0] = list[count];
-                    else if(list[count] != null)
-                        properList.Add(list[count]);
+                    var list = new List<Type>(
+                        assembly
+                        .GetTypes()
+                        .Where(t => t != typeof(ABDataSource))
+                        .Where(t => typeof(ABDataSource).IsAssignableFrom(t)));
+
+
+                    for (int count = 0; count < list.Count; count++)
+                    {
+                        if (list[count].Name == "AssetDatabaseABDataSource")
+                            properList[0] = list[count];
+                        else if (list[count] != null)
+                            properList.Add(list[count]);
+                    }
+                }
+                catch (System.Exception)
+                {
+                    //assembly which raises exception on the GetTypes() call - ignore it
                 }
             }
 


### PR DESCRIPTION
System.Reflection.TypeLoadException in the editor was raised when having an incompatible assembly to the GetTypes() call in ABDataSourceProvider.cs:31:

ReflectionTypeLoadException: The classes in the module cannot be loaded.
System.Reflection.Assembly.GetTypes () (at /Users/builduser/buildslave/mono/build/mcs/class/corlib/System.Reflection/Assembly.cs:371)
AssetBundleBrowser.AssetBundleDataSource.ABDataSourceProviderUtility.BuildCustomABDataSourceList () (at Assets/ExternalAssets/AssetBundles/AssetBundle-Browser/Editor/AssetBundleDataSource/ABDataSourceProvider.cs:31)
AssetBundleBrowser.AssetBundleDataSource.ABDataSourceProviderUtility.get_CustomABDataSourceTypes () (at Assets/ExternalAssets/AssetBundles/AssetBundle-Browser/Editor/AssetBundleDataSource/ABDataSourceProvider.cs:15)
AssetBundleBrowser.AssetBundleBrowserMain.InitDataSources () (at Assets/ExternalAssets/AssetBundles/AssetBundle-Browser/Editor/AssetBundleBrowserMain.cs:96)
AssetBundleBrowser.AssetBundleBrowserMain.OnEnable () (at Assets/ExternalAssets/AssetBundles/AssetBundle-Browser/Editor/AssetBundleBrowserMain.cs:89)

This is similar to a problem I encountered with Cinemachine: https://forum.unity.com/threads/system-reflection-reflectiontypeloadexception-the-classes-in-the-module-cannot-be-loaded.511989/

I don't really know what is the problem here, but I started with ignoring this assembly by adding a try-catch block. I'm happy for any better suggestions! Thanks
