### PR TITLE
Sorted dependencies

### DIFF
--- a/Editor/AssetBundleModel/ABModelAssetInfo.cs
+++ b/Editor/AssetBundleModel/ABModelAssetInfo.cs
@@ -176,7 +176,8 @@ namespace AssetBundleBrowser.AssetBundleModel
             if (m_dependencies != null && m_dependencies.Count > 0)
             {
                 var message = string.Empty;
-                foreach (var dependent in m_dependencies)
+				List<AssetInfo> sortedDependencies = m_dependencies.OrderBy(d => d.bundleName).ToList();
+                foreach (var dependent in sortedDependencies)
                 {
                     if (dependent.bundleName != bundleName)
                     {

--- a/Editor/AssetBundleModel/ABModelAssetInfo.cs
+++ b/Editor/AssetBundleModel/ABModelAssetInfo.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using UnityEditor;
 using System.Collections.Generic;
+using System.Linq
 using UnityEditor.IMGUI.Controls;
 
 namespace AssetBundleBrowser.AssetBundleModel

--- a/Editor/AssetBundleModel/ABModelAssetInfo.cs
+++ b/Editor/AssetBundleModel/ABModelAssetInfo.cs
@@ -177,7 +177,7 @@ namespace AssetBundleBrowser.AssetBundleModel
             if (m_dependencies != null && m_dependencies.Count > 0)
             {
                 var message = string.Empty;
-                List<AssetInfo> sortedDependencies = m_dependencies.OrderBy(d => d.bundleName).ToList();
+                var sortedDependencies = m_dependencies.OrderBy(d => d.bundleName);
                 foreach (var dependent in sortedDependencies)
                 {
                     if (dependent.bundleName != bundleName)

--- a/Editor/AssetBundleModel/ABModelAssetInfo.cs
+++ b/Editor/AssetBundleModel/ABModelAssetInfo.cs
@@ -176,7 +176,7 @@ namespace AssetBundleBrowser.AssetBundleModel
             if (m_dependencies != null && m_dependencies.Count > 0)
             {
                 var message = string.Empty;
-				List<AssetInfo> sortedDependencies = m_dependencies.OrderBy(d => d.bundleName).ToList();
+                List<AssetInfo> sortedDependencies = m_dependencies.OrderBy(d => d.bundleName).ToList();
                 foreach (var dependent in sortedDependencies)
                 {
                     if (dependent.bundleName != bundleName)


### PR DESCRIPTION
With a lot of dependencies, it becomes a bit cluttered, sorting by bundle name makes it a lot easier to navigate