### PR TITLE
Reload method getting called twice

### DIFF
--- a/Editor/AssetBundleTree.cs
+++ b/Editor/AssetBundleTree.cs
@@ -81,7 +81,6 @@ namespace AssetBundleBrowser
 
         protected override TreeViewItem BuildRoot()
         {
-            AssetBundleModel.Model.Refresh();
             var root = AssetBundleModel.Model.CreateBundleTreeView();
             return root;
         }


### PR DESCRIPTION
While creating my own AssetBundlePackagerBrowserIntergration I noticed hitting the refresh button in the top left corner of the asset bundle browser caused the GetAllAssetBundleNames method to be called twice. I'm doing some expensive operations in that method so it's pretty noticeable when it takes twice as long.

Looks like the AssetBundleInspectorTab was making a call to m_BundleTreeView.Reload(); which eventual calls Refresh and the AssetBundleTree class was making a call to AssetBundleModel.Model.Refresh(); causing the Refresh method to be invoked twice.

I chose to remove the AssetBundleModel.Model.Refresh(); line which resolved the issue for me.