### PR TITLE
Add support for building specific asset bundles

### DIFF
--- a/Editor/AssetBundleBuildTab.cs
+++ b/Editor/AssetBundleBuildTab.cs
@@ -292,6 +292,11 @@ namespace AssetBundleBrowser
 
         private void ExecuteBuild()
         {
+            ExecuteBuild(null);
+        }
+
+        public void ExecuteBuild(string[] assetBundleNames = null)
+        {
             if (AssetBundleModel.Model.DataSource.CanSpecifyBuildOutputDirectory) {
                 if (string.IsNullOrEmpty(m_UserData.m_OutputPath))
                     BrowseForFolder();
@@ -356,6 +361,23 @@ namespace AssetBundleBrowser
                 m_InspectTab.RefreshBundles();
             };
 
+            // Handle case where we're instructed to build particular asset bundles (and not all)
+            if (assetBundleNames != null)
+            {
+                AssetBundleBuild[] bundleBuilds = new AssetBundleBuild[assetBundleNames.Length];
+
+                for (int i = 0; i < bundleBuilds.Length; i++)
+                {
+                    AssetBundleBuild build = new AssetBundleBuild();
+                    build.assetBundleName = assetBundleNames[i];
+                    build.assetNames = AssetDatabase.GetAssetPathsFromAssetBundle(assetBundleNames[i]);
+
+                    bundleBuilds[i] = build;
+                }
+
+                buildInfo.bundleBuilds = bundleBuilds;
+            }
+
             AssetBundleModel.Model.DataSource.BuildAssetBundles (buildInfo);
 
             AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate);
@@ -363,7 +385,7 @@ namespace AssetBundleBrowser
             if(m_CopyToStreaming.state)
                 DirectoryCopy(m_UserData.m_OutputPath, m_streamingPath);
         }
-
+        
         private static void DirectoryCopy(string sourceDirName, string destDirName)
         {
             // If the destination directory doesn't exist, create it.

--- a/Editor/AssetBundleDataSource/ABDataSource.cs
+++ b/Editor/AssetBundleDataSource/ABDataSource.cs
@@ -44,6 +44,11 @@ namespace AssetBundleBrowser.AssetBundleDataSource
             set { m_onBuild = value; }
         }
         private Action<string> m_onBuild;
+
+        /// <summary>
+        /// Asset bundle build array (only when building specific bundles, and not all at once).
+        /// </summary>
+        public AssetBundleBuild[] bundleBuilds { get; set; }
     }
 
     /// <summary>

--- a/Editor/AssetBundleDataSource/AssetDatabaseABDataSource.cs
+++ b/Editor/AssetBundleDataSource/AssetDatabaseABDataSource.cs
@@ -84,7 +84,17 @@ namespace AssetBundleBrowser.AssetBundleDataSource
                 return false;
             }
 
-            var buildManifest = BuildPipeline.BuildAssetBundles(info.outputDirectory, info.options, info.buildTarget);
+            AssetBundleManifest buildManifest = null;
+            
+            if (info.bundleBuilds == null)
+            {
+                buildManifest = BuildPipeline.BuildAssetBundles(info.outputDirectory, info.options, info.buildTarget);
+            }
+            else
+            {
+                buildManifest = BuildPipeline.BuildAssetBundles(info.outputDirectory, info.bundleBuilds, info.options, info.buildTarget);
+            }
+
             if (buildManifest == null)
             {
                 Debug.Log("Error in build");

--- a/Editor/AssetBundleManageTab.cs
+++ b/Editor/AssetBundleManageTab.cs
@@ -273,5 +273,12 @@ namespace AssetBundleBrowser
         {
             m_AssetList.SetSelection( assets );
         }
+
+        internal void BuildSpecificAssetBundles(string[] assetBundleNames)
+        {
+            var main = m_Parent as AssetBundleBrowserMain;
+
+            EditorApplication.delayCall += () => { main.m_BuildTab.ExecuteBuild(assetBundleNames); };
+        }
     }
 }

--- a/Editor/AssetBundleTree.cs
+++ b/Editor/AssetBundleTree.cs
@@ -192,6 +192,10 @@ namespace AssetBundleBrowser
                 menu.AddItem(new GUIContent("Move duplicates existing in any selected"), false, DedupeAllBundles, selectedNodes);
                 menu.AddItem(new GUIContent("Delete " + selectedNodes.Count + " selected bundles"), false, DeleteBundles, selectedNodes);
             }
+            
+            // Add the context menu option to build the selected asset bundles
+            menu.AddItem(new GUIContent("Build " + selectedNodes.Count + " selected bundle(s)"), false, BuildBundles, selectedNodes);
+            
             menu.ShowAsContext();
         }
         void ForceReloadData(object context)
@@ -345,6 +349,15 @@ namespace AssetBundleBrowser
 
 
         }
+        
+        void BuildBundles(object b)
+        {
+            var selectedNodes = b as List<AssetBundleModel.BundleTreeItem>;
+            
+            m_Controller.BuildSpecificAssetBundles(selectedNodes.Select(n => n.bundle.m_Name.bundleName).ToArray());
+            ReloadAndSelect(new List<int>());
+        }
+        
         protected override void KeyEvent()
         {
             if (Event.current.keyCode == KeyCode.Delete && GetSelection().Count > 0)


### PR DESCRIPTION
This is added by invovking the correct overload of `BuildPipeline.BuildAssetBundles` (the one accepting AssetBundleBuild[]).

Since the tree view (of the "manage" tab is the one actually containing most of the logic for handling context menu click, some additional things were needed to make this work).

TreeView will call its "controller" (e.g: manage tab) which in turn has a reference to the top window (parent). From that point, we exposed a method to actually call the build, which will invoke the build tab's build method.
