### PR TITLE
Fix the asset bundle browser showing the on-disk size, not imported size

### DIFF
--- a/Editor/AssetBundleModel/ABModelAssetInfo.cs
+++ b/Editor/AssetBundleModel/ABModelAssetInfo.cs
@@ -97,12 +97,19 @@ namespace AssetBundleBrowser.AssetBundleModel
                 m_AssetName = value;
                 m_DisplayName = System.IO.Path.GetFileNameWithoutExtension(m_AssetName);
 
-                //TODO - maybe there's a way to ask the AssetDatabase for this size info.
                 System.IO.FileInfo fileInfo = new System.IO.FileInfo(m_AssetName);
                 if (fileInfo.Exists)
-                    fileSize = fileInfo.Length;
+                {
+                    Object obj = AssetDatabase.LoadMainAssetAtPath(m_AssetName);
+                    fileSize = UnityEngine.Profiling.Profiler.GetRuntimeMemorySizeLong(obj);
+                    // The above isn't supported for all asset types:
+                    if (fileSize == 0)
+                        fileSize = fileInfo.Length;
+                }
                 else
+                {
                     fileSize = 0;
+                }
             }
         }
         internal string displayName


### PR DESCRIPTION
This fixes #129 by using a profiler API call to check how large each asset will be after import. For assets that aren't supported, it falls back to the old method of checking the size on disk.

Something to be aware of: the size shown is a size in memory rather than a size in the asset bundle. So an audio clip which is decompressed upon loading will have a large size shown.