### PR TITLE
Fix: asset folders view with the same folder name, added to a single bundle

### DIFF
--- a/Editor/AssetBundleModel/ABModelBundleInfo.cs
+++ b/Editor/AssetBundleModel/ABModelBundleInfo.cs
@@ -371,7 +371,7 @@ namespace AssetBundleBrowser.AssetBundleModel
                     {
                         var folderAsset = Model.CreateAsset(partialPath, bundleName);
                         folderAsset.isFolder = true;
-                        if (m_ConcreteAssets.FindIndex(a => a.displayName == folderAsset.displayName) == -1)
+                        if (m_ConcreteAssets.FindIndex(a => a.fullAssetName == folderAsset.fullAssetName) == -1)
                         {
                             m_ConcreteAssets.Add(folderAsset);
                         }


### PR DESCRIPTION
Issue: If you add two folders with the same folder name to a single asset bundle, bundles browser shows only one folder.

Here is an example:
I added folders 'Assets/Images/Game/Elements' and 'Assets/Images/LevelEditor/Elements' to asset bundle 

Before fix
![image](https://user-images.githubusercontent.com/50715402/89667288-2c8c0500-d8dc-11ea-9157-7701ba755937.png)


After fix
![image](https://user-images.githubusercontent.com/50715402/89667937-4bd76200-d8dd-11ea-81f5-607c8a106bae.png)

