### PR TITLE
fix  NullReferenceException by package assets

### DIFF
--- a/Editor/AssetBundleModel/ABModel.cs
+++ b/Editor/AssetBundleModel/ABModel.cs
@@ -676,7 +676,7 @@ namespace AssetBundleBrowser.AssetBundleModel
 
         internal static bool ValidateAsset(string name)
         {
-            if (!name.StartsWith("Assets/"))
+            if (!name.StartsWith("Assets/") && !name.StartsWith("Packages/"))
                 return false;
             string ext = System.IO.Path.GetExtension(name);
             if (ext == ".dll" || ext == ".cs" || ext == ".meta" || ext == ".js" || ext == ".boo")


### PR DESCRIPTION
NullReferenceException: Object reference not set to an instance of an object
AssetBundleBrowser.AssetBundleModel.BundleDataInfo.RefreshAssetList () (at Library/PackageCache/com.unity.assetbundlebrowser@b7c279278d/Editor/AssetBundleModel/ABModelBundleInfo.cs:373)