### PR TITLE
Add bundle picker to Build tab for building single asset bundles

### DIFF
--- a/Editor/AssetBundleBuildTab.cs
+++ b/Editor/AssetBundleBuildTab.cs
@@ -204,7 +204,14 @@ namespace AssetBundleBrowser
             if (m_UserData.m_SelectedBundleIndex >= displayOptions.Length)
                 m_UserData.m_SelectedBundleIndex = 0;
             m_UserData.m_SelectedBundleIndex = EditorGUILayout.Popup(
-                "Bundle", m_UserData.m_SelectedBundleIndex, displayOptions);
+                new GUIContent("Bundle", "Build a single bundle for fast iteration. Only the selected bundle is passed to the build pipeline."),
+                m_UserData.m_SelectedBundleIndex, displayOptions);
+            if (m_UserData.m_SelectedBundleIndex > 0)
+            {
+                EditorGUILayout.HelpBox(
+                    "Building a single bundle may duplicate assets that are shared with other bundles. Use a full build for production output.",
+                    MessageType.Warning);
+            }
 
             ////output path
             using (new EditorGUI.DisabledScope (!AssetBundleModel.Model.DataSource.CanSpecifyBuildOutputDirectory)) {

--- a/Editor/AssetBundleBuildTab.cs
+++ b/Editor/AssetBundleBuildTab.cs
@@ -393,14 +393,9 @@ namespace AssetBundleBrowser
                         return;
                     }
 
-                    string bundleName = fullName;
-                    string variantName = string.Empty;
-                    int dotIndex = fullName.LastIndexOf('.');
-                    if (dotIndex >= 0)
-                    {
-                        bundleName = fullName.Substring(0, dotIndex);
-                        variantName = fullName.Substring(dotIndex + 1);
-                    }
+                    var importer = AssetImporter.GetAtPath(assetPaths[0]);
+                    string bundleName = importer.assetBundleName;
+                    string variantName = importer.assetBundleVariant;
 
                     AssetBundleBuild build = new AssetBundleBuild();
                     build.assetBundleName = bundleName;

--- a/Editor/AssetBundleBuildTab.cs
+++ b/Editor/AssetBundleBuildTab.cs
@@ -194,6 +194,17 @@ namespace AssetBundleBrowser
                 }
             }
 
+            // bundle selection
+            EditorGUILayout.Space();
+            var bundleNames = AssetBundleModel.Model.DataSource.GetAllAssetBundleNames();
+            var displayOptions = new string[bundleNames.Length + 1];
+            displayOptions[0] = "All Bundles";
+            for (int i = 0; i < bundleNames.Length; i++)
+                displayOptions[i + 1] = bundleNames[i];
+            if (m_UserData.m_SelectedBundleIndex >= displayOptions.Length)
+                m_UserData.m_SelectedBundleIndex = 0;
+            m_UserData.m_SelectedBundleIndex = EditorGUILayout.Popup(
+                "Bundle", m_UserData.m_SelectedBundleIndex, displayOptions);
 
             ////output path
             using (new EditorGUI.DisabledScope (!AssetBundleModel.Model.DataSource.CanSpecifyBuildOutputDirectory)) {
@@ -304,24 +315,31 @@ namespace AssetBundleBrowser
 
                 if (m_ForceRebuild.state)
                 {
-                    string message = "Do you want to delete all files in the directory " + m_UserData.m_OutputPath;
-                    if (m_CopyToStreaming.state)
-                        message += " and " + m_streamingPath;
-                    message += "?";
-                    if (EditorUtility.DisplayDialog("File delete confirmation", message, "Yes", "No"))
+                    if (m_UserData.m_SelectedBundleIndex > 0)
                     {
-                        try
+                        Debug.Log("AssetBundle Build: Skipping 'Clear Folders' when building a single bundle.");
+                    }
+                    else
+                    {
+                        string message = "Do you want to delete all files in the directory " + m_UserData.m_OutputPath;
+                        if (m_CopyToStreaming.state)
+                            message += " and " + m_streamingPath;
+                        message += "?";
+                        if (EditorUtility.DisplayDialog("File delete confirmation", message, "Yes", "No"))
                         {
-                            if (Directory.Exists(m_UserData.m_OutputPath))
-                                Directory.Delete(m_UserData.m_OutputPath, true);
+                            try
+                            {
+                                if (Directory.Exists(m_UserData.m_OutputPath))
+                                    Directory.Delete(m_UserData.m_OutputPath, true);
 
-                            if (m_CopyToStreaming.state)
-                            if (Directory.Exists(m_streamingPath))
-                                Directory.Delete(m_streamingPath, true);
-                        }
-                        catch (System.Exception e)
-                        {
-                            Debug.LogException(e);
+                                if (m_CopyToStreaming.state)
+                                if (Directory.Exists(m_streamingPath))
+                                    Directory.Delete(m_streamingPath, true);
+                            }
+                            catch (System.Exception e)
+                            {
+                                Debug.LogException(e);
+                            }
                         }
                     }
                 }
@@ -355,6 +373,42 @@ namespace AssetBundleBrowser
                 m_InspectTab.AddBundleFolder(buildInfo.outputDirectory);
                 m_InspectTab.RefreshBundles();
             };
+
+            if (m_UserData.m_SelectedBundleIndex > 0)
+            {
+                var allBundleNames = AssetBundleModel.Model.DataSource.GetAllAssetBundleNames();
+                int bundleIdx = m_UserData.m_SelectedBundleIndex - 1;
+                if (bundleIdx >= allBundleNames.Length)
+                {
+                    Debug.LogError("AssetBundle Build: Selected bundle index is out of range. Resetting to All Bundles.");
+                    m_UserData.m_SelectedBundleIndex = 0;
+                }
+                else
+                {
+                    string fullName = allBundleNames[bundleIdx];
+                    string[] assetPaths = AssetBundleModel.Model.DataSource.GetAssetPathsFromAssetBundle(fullName);
+                    if (assetPaths == null || assetPaths.Length == 0)
+                    {
+                        Debug.LogWarning("AssetBundle Build: Bundle '" + fullName + "' has no assets. Skipping build.");
+                        return;
+                    }
+
+                    string bundleName = fullName;
+                    string variantName = string.Empty;
+                    int dotIndex = fullName.LastIndexOf('.');
+                    if (dotIndex >= 0)
+                    {
+                        bundleName = fullName.Substring(0, dotIndex);
+                        variantName = fullName.Substring(dotIndex + 1);
+                    }
+
+                    AssetBundleBuild build = new AssetBundleBuild();
+                    build.assetBundleName = bundleName;
+                    build.assetBundleVariant = variantName;
+                    build.assetNames = assetPaths;
+                    buildInfo.bundlesToBuild = new AssetBundleBuild[] { build };
+                }
+            }
 
             AssetBundleModel.Model.DataSource.BuildAssetBundles (buildInfo);
 
@@ -455,6 +509,7 @@ namespace AssetBundleBrowser
             internal CompressOptions m_Compression = CompressOptions.StandardCompression;
             internal string m_OutputPath = string.Empty;
             internal bool m_UseDefaultPath = true;
+            internal int m_SelectedBundleIndex = 0; // 0 = All Bundles
         }
     }
 

--- a/Editor/AssetBundleDataSource/ABDataSource.cs
+++ b/Editor/AssetBundleDataSource/ABDataSource.cs
@@ -44,6 +44,15 @@ namespace AssetBundleBrowser.AssetBundleDataSource
             set { m_onBuild = value; }
         }
         private Action<string> m_onBuild;
+        /// <summary>
+        /// Specific bundles to build. If null or empty, all bundles are built.
+        /// </summary>
+        public AssetBundleBuild[] bundlesToBuild
+        {
+            get { return m_bundlesToBuild; }
+            set { m_bundlesToBuild = value; }
+        }
+        private AssetBundleBuild[] m_bundlesToBuild;
     }
 
     /// <summary>

--- a/Editor/AssetBundleDataSource/AssetDatabaseABDataSource.cs
+++ b/Editor/AssetBundleDataSource/AssetDatabaseABDataSource.cs
@@ -84,7 +84,17 @@ namespace AssetBundleBrowser.AssetBundleDataSource
                 return false;
             }
 
-            var buildManifest = BuildPipeline.BuildAssetBundles(info.outputDirectory, info.options, info.buildTarget);
+            AssetBundleManifest buildManifest;
+            if (info.bundlesToBuild != null && info.bundlesToBuild.Length > 0)
+            {
+                buildManifest = BuildPipeline.BuildAssetBundles(
+                    info.outputDirectory, info.bundlesToBuild, info.options, info.buildTarget);
+            }
+            else
+            {
+                buildManifest = BuildPipeline.BuildAssetBundles(
+                    info.outputDirectory, info.options, info.buildTarget);
+            }
             if (buildManifest == null)
             {
                 Debug.Log("Error in build");


### PR DESCRIPTION
Instead of always building all bundles, users can now select a specific bundle from a dropdown on the Build tab. Uses the AssetBundleBuild[] overload of BuildPipeline.BuildAssetBundles when a single bundle is selected. Skips "Clear Folders" for single-bundle builds to avoid destroying other built bundles.